### PR TITLE
Fix issue with null and blank values

### DIFF
--- a/django_admin_hstore_widget/forms.py
+++ b/django_admin_hstore_widget/forms.py
@@ -8,4 +8,6 @@ class HStoreFormField(HStoreField):
     widget = HStoreFormWidget
 
     def clean(self, value):
+        if not value:
+            value = '{}'
         return json.loads(value)


### PR DESCRIPTION
Hi! first of all thanks for this project :)

I've got an issue when I have a field like:

    variables = HStoreField(null=True, blank=True)

in the admin, I always get an JSONDecodeError when trying to decode the empty field. In this simple PR I just check if the value it's empty or null and assign an empty JSON. I think I could achieve the same with a default in the model though.