### PR TITLE
Add Django 4 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
   include:
     # PYTHON 3.8
     - { python: "3.8", env: DJANGO=3.0 }
+    - { python: "3.8", env: DJANGO=4.0 }
     # PYTHON 3.7
     - { python: "3.7", env: DJANGO=3.0 }
     - { python: "3.7", env: DJANGO=2.2 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ FormField that properly render HStoreField Data in django Admin based on [django
 
 ## Requirements
  * Python 2.7, 3.4, 3.5, 3.6, 3.7, 3.8
- * Django 1.11, 2.0, 2.1, 2.2, 3.0
+ * Django 1.11, 2.0, 2.1, 2.2, 3.0, 4.0
  
  
 Using pip:

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
        {py35,py36,py37}-django22,
        {py36,py37}-django30,
        {py38}-django30,
+       {py38}-django40,
 
 
 [travis:env]
@@ -15,6 +16,7 @@ DJANGO =
     2.1: django21
     2.2: django22
     3.0: django30
+    4.0: django40
 
 [latest]
 deps =
@@ -31,4 +33,5 @@ deps =
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3.0
     django30: Django>=3.0,<3.1
+    django40: Django>=4.0,<4.1
     -rrequirements/test-ci.txt


### PR DESCRIPTION
Greetings @PokaInc 

I am introducing this small PR to see if Django 4.0 test run would pass and get a bit of your input on this repository.
We definitely can bring some love here, switch CI to GitHub Actions and remove deprecated and obsolete Python and Django versions. This is not a big deal, but it would be nice to get a green light from maintainers before anyone would proceed with such changes.
What do you think?
