### PR TITLE
Update widgets.py

### DIFF
--- a/django_admin_hstore_widget/widgets.py
+++ b/django_admin_hstore_widget/widgets.py
@@ -13,7 +13,7 @@ class HStoreFormWidget(AdminTextareaWidget):
     @property
     def media(self):
         internal_js = [
-            "django_admin_hstore_widget/underscore-min.js",
+            "django_admin_hstore_widget/underscore.js",
             "django_admin_hstore_widget/django_admin_hstore_widget.js"
         ]
 


### PR DESCRIPTION
django 4 ManifestStaticFilesStorage write 
The file 'admin/js/django_admin_hstore_widget/underscore-min.map' could not be found with <django.contrib.staticfiles.storage.ManifestStaticFilesStorage object at 0x7f2e62498d30>.